### PR TITLE
Capture Preference for Minimum Baseline Age of 1 year

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,26 @@
+{
+  "audit-trail-plugin": {
+    "baselineMinAge": {
+      "value": "1y",
+      "ref": "https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/97#issuecomment-1842430268"
+    }
+  },
+  "cloudbees-disk-usage-simple-plugin": {
+    "baselineMinAge": {
+      "value": "1y",
+      "ref": "https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/97#issuecomment-1842430268"
+    }
+  },
+  "cloudbees-jenkins-advisor-plugin": {
+    "baselineMinAge": {
+      "value": "1y",
+      "ref": "https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/97#issuecomment-1842430268"
+    }
+  },
+  "shelve-project-plugin": {
+    "baselineMinAge": {
+      "value": "1y",
+      "ref": "https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/97#issuecomment-1842430268"
+    }
+  }
+}


### PR DESCRIPTION
Captures the preference to not get baseline updates as soon as they're recommended, but to wait until they've been out a year.

As requested in https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/97#issuecomment-1842430268